### PR TITLE
Add image zoom

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -20,6 +20,7 @@ RUN HOME=/opt/workshop/renderer && \
     npm install --production
 
 COPY gateway/. /opt/workshop/gateway/.
+COPY renderer/static/css/image-overlay.css /opt/workshop/gateway/static/css/image-overlay.css
 
 COPY bin/. /opt/workshop/bin/.
 COPY etc/. /opt/workshop/etc/.

--- a/dashboard/gateway/views/dashboard.pug
+++ b/dashboard/gateway/views/dashboard.pug
@@ -18,6 +18,7 @@ html
         script(src="../static/js/bootstrap.min.js")
         script(src="../static/js/require.min.js")
         link(rel='stylesheet', href="../static/css/bootstrap.min.css")
+        link(rel='stylesheet', href="../static/css/image-overlay.css")
 
         style.
             html, body {

--- a/dashboard/renderer/static/css/image-overlay.css
+++ b/dashboard/renderer/static/css/image-overlay.css
@@ -1,0 +1,76 @@
+/* The Overlay (background) */
+
+.overlay {
+    /* Height & width depends on how you want to reveal the overlay (see JS below) */
+    height: 100%;
+    width: 0;
+    position: fixed;
+    /* Stay in place */
+    z-index: 1;
+    /* Sit on top */
+    left: 0;
+    top: 0;
+    background-color: rgb(0, 0, 0);
+    /* Black fallback color */
+    background-color: rgba(0, 0, 0, 0.9);
+    /* Black w/opacity */
+    overflow-x: hidden;
+    /* Disable horizontal scroll */
+    transition: 0.5s;
+    /* 0.5 second transition effect to slide in or slide down the overlay (height or width, depending on reveal) */
+}
+
+/* Position the content inside the overlay */
+
+.overlay-content {
+    position: relative;
+    top: 25%;
+    /* 25% from the top */
+    width: 100%;
+    /* 100% width */
+    text-align: center;
+    /* Centered text/links */
+    margin-top: 30px;
+    /* 30px top margin to avoid conflict with the close button on smaller screens */
+}
+
+/* The navigation links inside the overlay */
+
+.overlay a {
+    padding: 8px;
+    text-decoration: none;
+    font-size: 36px;
+    color: #818181;
+    display: block;
+    /* Display block instead of inline */
+    transition: 0.3s;
+    /* Transition effects on hover (color) */
+}
+
+/* When you mouse over the navigation links, change their color */
+
+.overlay a:hover, .overlay a:focus {
+    color: #f1f1f1;
+}
+
+/* Position the close button (top right corner) */
+
+.overlay .closebtn {
+    position: absolute;
+    top: 20px;
+    right: 45px;
+    font-size: 60px;
+}
+
+/* When the height of the screen is less than 450 pixels, change the font-size of the links and position the close button again, so they don't overlap */
+
+@media screen and (max-height: 450px) {
+    .overlay a {
+        font-size: 20px
+    }
+    .overlay .closebtn {
+        font-size: 40px;
+        top: 15px;
+        right: 35px;
+    }
+}

--- a/dashboard/renderer/static/js/workshop.js
+++ b/dashboard/renderer/static/js/workshop.js
@@ -41,6 +41,20 @@ function selectElementText(el, win) {
     }
 }
 $(document).ready(function() {
+    $("img").click(function() {
+        const overlay = `<div id="myNav" style="width:100%" class="overlay"><a href="javascript:void(0)" class="closebtn" onclick="document.getElementById('myNav').remove();">&times;</a><div class="overlay-content"><img src="${$(this)[0].src}" alt="test" /></div></div>`;
+        if (window.location !== window.parent.location) {
+            parent.$("body").append(overlay);
+        }
+        else {
+            $("body").append(overlay);
+        }
+    });
+
+    $("img").hover(function() {
+        $(this).css('cursor','pointer');
+    });
+
     $('section.page-content a').each(function() {
         function normalize(path){
             path = Array.prototype.join.apply(arguments,['/'])

--- a/dashboard/renderer/views/page.liquid
+++ b/dashboard/renderer/views/page.liquid
@@ -22,6 +22,7 @@
   {% endif %}
   <link rel="stylesheet" href="{{ config.base_url }}/bootstrap/css/bootstrap.min.css">
   <link rel="stylesheet" href="{{ config.base_url }}/fontawesome/css/all.min.css">
+  <link rel="stylesheet" href="{{ config.base_url }}/css/image-overlay.css">
   <link rel="stylesheet" href="{{ config.base_url }}/css/workshop.css">
   <link rel="stylesheet" href="{{ config.base_url }}/css/workshop-{{ module.format }}.css">
   {{ config.analytics }}


### PR DESCRIPTION
closes #5 
![image](https://user-images.githubusercontent.com/5431427/100295997-14a6c280-2f59-11eb-921c-30a9dd6e43e7.png)
Clicking an image in the labguide pops it out in an overlay
![image](https://user-images.githubusercontent.com/5431427/100296026-28522900-2f59-11eb-96a7-81b398264dff.png)
Then click X in the top right to exit